### PR TITLE
Create Social Safe marketing site and intake APIs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-img-element": "off"
+  }
+}

--- a/app/api/assist/route.ts
+++ b/app/api/assist/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { assistSchema } from "@/lib/schemas";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+export async function POST(request: Request) {
+  const ip = request.headers.get("x-forwarded-for") ?? "anonymous";
+  if (!checkRateLimit(`assist:${ip}`)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  try {
+    const json = await request.json();
+    const payload = assistSchema.parse(json);
+    const last = payload.messages[payload.messages.length - 1];
+    const reply =
+      last?.content
+        ? `Here’s a quick tip: focus on secure evidence (screenshots, invoices) and avoid sharing passwords. Summarise changes since the incident to speed up analyst review.`
+        : "How can I help with your recovery?";
+    return NextResponse.json({ reply });
+  } catch (error) {
+    console.error("[assist]", { message: (error as Error).message });
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+}

--- a/app/api/cases/route.ts
+++ b/app/api/cases/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { caseSchema } from "@/lib/schemas";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { createCase } from "@/lib/store/cases";
+
+export async function POST(request: Request) {
+  const ip = request.headers.get("x-forwarded-for") ?? "anonymous";
+  if (!checkRateLimit(`cases:${ip}`)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  try {
+    const json = await request.json();
+    const parsed = caseSchema.omit({ honey: true }).parse({ ...json, honey: "" });
+    const record = await createCase(parsed);
+    return NextResponse.json({ id: record.id });
+  } catch (error) {
+    console.error("[case-api]", { message: (error as Error).message });
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+}

--- a/app/api/notify-ops/route.ts
+++ b/app/api/notify-ops/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { notifyOpsSchema } from "@/lib/schemas";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+export async function POST(request: Request) {
+  const ip = request.headers.get("x-forwarded-for") ?? "anonymous";
+  if (!checkRateLimit(`ops:${ip}`)) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  try {
+    const json = await request.json();
+    const payload = notifyOpsSchema.parse(json);
+    console.info("[notify-ops]", {
+      email: payload.email,
+      platform: payload.platform,
+      caseId: payload.caseId
+    });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[notify-ops]", { message: (error as Error).message });
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import { ContactForm } from "@/components/forms/ContactForm";
+import { WhatsAppCTA } from "@/components/WhatsAppCTA";
+import { WHATSAPP_URL } from "@/lib/constants";
+
+export const metadata: Metadata = {
+  title: "Contact | Social Safe",
+  description:
+    "Request Social Safe account recovery support. Share your case details securely and our analysts will respond within business hours.",
+  alternates: {
+    canonical: "https://www.socialsafe.my/contact"
+  }
+};
+
+export default function ContactPage() {
+  return (
+    <div className="space-y-12">
+      <section className="space-y-4">
+        <h1 className="text-4xl font-bold text-slate-900">Talk to Social Safe</h1>
+        <p className="max-w-2xl text-sm text-slate-600">
+          Provide your details and we’ll triage the incident. We never request passwords or 2FA codes. For urgent cases, tap WhatsApp to chat with a specialist.
+        </p>
+        <p className="rounded-2xl bg-white p-4 text-sm text-slate-700 shadow-sm">
+          We charge a RM 100 advance to open a case. This is non-refundable and covers analyst time and evidence preparation. You only pay the remaining success fee if we recover access.
+        </p>
+      </section>
+      <section className="grid gap-10 lg:grid-cols-2">
+        <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <ContactForm />
+        </div>
+        <aside className="space-y-4 rounded-2xl border border-blue-100 bg-blue-50 p-6 text-sm text-slate-700">
+          <h2 className="text-2xl font-semibold text-slate-900">Prefer messaging?</h2>
+          <p>
+            Reach us directly on WhatsApp during 9am–10pm MYT. Real humans respond with a step-by-step checklist tailored to your platform.
+          </p>
+          <a
+            href={WHATSAPP_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center justify-center rounded-2xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow-soft"
+          >
+            Message us on WhatsApp
+          </a>
+        </aside>
+      </section>
+      <WhatsAppCTA />
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 antialiased;
+}
+
+a {
+  @apply underline-offset-4;
+}
+
+.focus-ring {
+  @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,89 @@
+import "./globals.css";
+
+import type { Metadata } from "next";
+import { Manrope, Plus_Jakarta_Sans } from "next/font/google";
+import Script from "next/script";
+import { ReactNode } from "react";
+import { Header } from "@/components/layout/Header";
+import { Footer } from "@/components/layout/Footer";
+import { ConsentBanner } from "@/components/layout/ConsentBanner";
+import { AssistWidget } from "@/components/layout/AssistWidget";
+import { SITE_NAME, SITE_URL } from "@/lib/constants";
+
+const display = Plus_Jakarta_Sans({
+  subsets: ["latin"],
+  variable: "--font-display",
+  weight: ["600", "700"],
+  display: "swap"
+});
+
+const sans = Manrope({
+  subsets: ["latin"],
+  variable: "--font-sans",
+  weight: ["400", "500", "600"],
+  display: "swap"
+});
+
+export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "SocialSafe.my — Social Account Recovery in Malaysia.",
+    template: "%s | Social Safe"
+  },
+  description:
+    "Hacked, locked, or disabled? Social Safe restores access to Instagram, Facebook, TikTok, X/Twitter and YouTube. Fast, secure, and ethical.",
+  openGraph: {
+    title: "SocialSafe.my — Social Account Recovery in Malaysia.",
+    description:
+      "Hacked, locked, or disabled? Social Safe restores access to Instagram, Facebook, TikTok, X/Twitter and YouTube. Fast, secure, and ethical.",
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    locale: "en_MY",
+    type: "website"
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "SocialSafe.my — Social Account Recovery in Malaysia.",
+    description:
+      "Hacked, locked, or disabled? Social Safe restores access to Instagram, Facebook, TikTok, X/Twitter and YouTube. Fast, secure, and ethical."
+  }
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: SITE_NAME,
+    url: SITE_URL,
+    sameAs: [
+      "https://www.facebook.com/socialsafe",
+      "https://www.instagram.com/socialsafe",
+      "https://www.linkedin.com/company/socialsafe"
+    ]
+  };
+
+  return (
+    <html lang="en" className={`${sans.variable} ${display.variable}`}>
+      <body className="min-h-screen bg-slate-50">
+        <a
+          href="#main"
+          className="focus-ring absolute left-4 top-4 -translate-y-16 rounded-2xl bg-blue-600 px-4 py-2 text-sm font-semibold text-white focus:translate-y-0"
+        >
+          Skip to content
+        </a>
+        <Header />
+        <main id="main" className="mx-auto max-w-6xl px-4 pb-20 pt-10">
+          {children}
+        </main>
+        <Footer />
+        <ConsentBanner />
+        <AssistWidget />
+        <Script
+          id="jsonld"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { HomeContent } from "@/components/home/HomeContent";
+
+export const metadata: Metadata = {
+  title: "SocialSafe.my — Social Account Recovery in Malaysia.",
+  description:
+    "Hacked, locked, or disabled? Social Safe restores access to Instagram, Facebook, TikTok, X/Twitter and YouTube. Fast, secure, and ethical.",
+  alternates: {
+    canonical: "https://www.socialsafe.my/"
+  }
+};
+
+export default function Page() {
+  return <HomeContent />;
+}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import { PriceCard } from "@/components/cards/PriceCard";
+
+export const metadata: Metadata = {
+  title: "Pricing | Social Safe",
+  description:
+    "Choose the right Social Safe recovery tier. Basic, Standard, and Priority success fees with transparent advance policy.",
+  alternates: {
+    canonical: "https://www.socialsafe.my/pricing"
+  }
+};
+
+const pricing = [
+  {
+    title: "Basic",
+    subtitle: "DIY + AI",
+    successFee: 199,
+    features: [
+      "AI assistant guidance",
+      "Security checklist",
+      "Email template pack",
+      "Shadowban review basics"
+    ]
+  },
+  {
+    title: "Standard",
+    subtitle: "Most cases",
+    successFee: 399,
+    features: [
+      "One platform recovery",
+      "Analyst updates 24–72h",
+      "Ownership verification support",
+      "Post-recovery hardening",
+      "Impersonation takedown included where marked"
+    ]
+  },
+  {
+    title: "Priority",
+    subtitle: "Urgent & business",
+    successFee: 899,
+    features: [
+      "Fast-track queue under 24h",
+      "Multi-platform support",
+      "Dedicated case manager",
+      "Impersonation takedown pack"
+    ]
+  }
+];
+
+export default function PricingPage() {
+  return (
+    <div className="space-y-12">
+      <section className="space-y-4">
+        <h1 className="text-4xl font-bold text-slate-900">Transparent pricing</h1>
+        <p className="max-w-2xl text-sm text-slate-600">
+          Recovery isn’t one-size-fits-all. Choose a tier that matches your urgency, platform coverage, and analyst involvement.
+        </p>
+        <p className="rounded-2xl bg-white p-4 text-sm text-slate-700 shadow-sm">
+          We charge a RM 100 advance to open a case. This is non-refundable and covers analyst time and evidence preparation. You only pay the remaining success fee if we recover access.
+        </p>
+      </section>
+      <section className="grid gap-6 md:grid-cols-3">
+        {pricing.map((plan) => (
+          <PriceCard
+            key={plan.title}
+            title={plan.title}
+            subtitle={plan.subtitle}
+            successFee={plan.successFee}
+            features={plan.features}
+          />
+        ))}
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-slate-900">What the advance covers</h2>
+        <ul className="space-y-2 text-sm text-slate-600">
+          <li>Security analyst review of case evidence</li>
+          <li>Preparation of compliant appeals and ownership packets</li>
+          <li>Guided communication on what to send platform support</li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Social Safe",
+  description: "Understand how Social Safe handles your information with lawful, minimal data practices.",
+  alternates: {
+    canonical: "https://www.socialsafe.my/privacy"
+  }
+};
+
+export default function PrivacyPage() {
+  return (
+    <article className="prose prose-slate max-w-none">
+      <h1>Privacy Policy</h1>
+      <p>Last updated: May 2024</p>
+      <p>
+        Social Safe operates with a minimum data mindset. We collect only the information you provide in recovery requests to triage and service your case. We do not request or store passwords, 2FA codes, or payment details through this site.
+      </p>
+      <h2>Information we collect</h2>
+      <ul>
+        <li>Contact details (name, email, optional phone)</li>
+        <li>Platform and incident information you share</li>
+        <li>Operational metadata such as case timestamps</li>
+      </ul>
+      <h2>How we use information</h2>
+      <p>
+        We use your information to verify ownership, prepare evidence packs, communicate with you, and deliver contracted recovery services. We may anonymise case learnings to improve processes.
+      </p>
+      <h2>Retention</h2>
+      <p>
+        Case data is retained for up to 12 months for audit and compliance purposes, after which it is securely deleted unless lawfully required otherwise.
+      </p>
+      <h2>Your rights</h2>
+      <p>
+        You may request access, correction, or deletion of your information by emailing privacy@socialsafe.my. We respond within 30 days.
+      </p>
+      <h2>Contact</h2>
+      <p>
+        Questions about this policy can be directed to privacy@socialsafe.my. We operate independently and follow platform policies and applicable laws.
+      </p>
+    </article>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Service | Social Safe",
+  description: "Review Social Safe’s service terms, lawful conduct commitments, and customer responsibilities.",
+  alternates: {
+    canonical: "https://www.socialsafe.my/terms"
+  }
+};
+
+export default function TermsPage() {
+  return (
+    <article className="prose prose-slate max-w-none">
+      <h1>Terms of Service</h1>
+      <p>Last updated: May 2024</p>
+      <h2>Scope of services</h2>
+      <p>
+        Social Safe provides advisory, documentation, and liaison support for account recovery, impersonation takedowns, and post-recovery hardening. We operate independently and follow platform policies and applicable laws.
+      </p>
+      <h2>Client responsibilities</h2>
+      <ul>
+        <li>Provide accurate ownership evidence when requested.</li>
+        <li>Do not share passwords, one-time codes, or sensitive authentication factors.</li>
+        <li>Comply with all applicable platform terms of service.</li>
+      </ul>
+      <h2>Fees</h2>
+      <p>
+        We charge a RM 100 advance to open a case. This is non-refundable and covers analyst time and evidence preparation. You only pay the remaining success fee if we recover access.
+      </p>
+      <h2>Liability</h2>
+      <p>
+        While we apply best-effort, lawful processes, Social Safe does not guarantee outcomes and is not liable for indirect or consequential damages. Liability is limited to fees paid for the relevant engagement.
+      </p>
+      <h2>Contact</h2>
+      <p>
+        For questions about these terms, email legal@socialsafe.my.
+      </p>
+    </article>
+  );
+}

--- a/components/WhatsAppCTA.tsx
+++ b/components/WhatsAppCTA.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { MessageCircle } from "lucide-react";
+import { motion } from "framer-motion";
+import { Button } from "@/components/ui/button";
+import { BUSINESS_HOURS_BADGE, WHATSAPP_URL } from "@/lib/constants";
+
+const quickLinks = [
+  "Instagram hacked",
+  "Business account disabled",
+  "Need account appeal",
+  "Impersonation takedown"
+];
+
+export function WhatsAppCTA() {
+  return (
+    <section
+      aria-labelledby="whatsapp-support"
+      className="rounded-2xl bg-whatsapp-gradient p-8 shadow-soft"
+    >
+      <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div className="max-w-2xl space-y-4">
+          <div className="inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-1 text-xs font-semibold text-emerald-600">
+            <MessageCircle className="h-4 w-4" aria-hidden="true" />
+            <span>{BUSINESS_HOURS_BADGE}</span>
+          </div>
+          <div>
+            <h2 id="whatsapp-support" className="text-2xl font-bold text-slate-900">
+              Chat with a specialist on WhatsApp
+            </h2>
+            <p className="text-sm text-slate-700">
+              Real humans answer within business hours. Share what happened and we’ll guide your next steps.
+            </p>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-600">
+              Typical response under 30 minutes during 9am–10pm MYT.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {quickLinks.map((label) => {
+              const url = `${WHATSAPP_URL}?text=${encodeURIComponent(label)}`;
+              return (
+                <Button
+                  key={label}
+                  asChild
+                  variant="outline"
+                  size="sm"
+                  className="bg-white/90"
+                >
+                  <a href={url} target="_blank" rel="noreferrer noopener">
+                    {label}
+                  </a>
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+        <motion.div
+          className="w-full max-w-xs rounded-2xl bg-white p-6 shadow-lg"
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.4 }}
+        >
+          <p className="text-sm font-semibold text-slate-900">Need hands-on help?</p>
+          <p className="mt-2 text-sm text-slate-600">
+            Our recovery analysts are on standby to triage your case and start evidence prep.
+          </p>
+          <Button asChild className="mt-6 w-full">
+            <a href={WHATSAPP_URL} target="_blank" rel="noreferrer noopener">
+              Message us on WhatsApp
+            </a>
+          </Button>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/components/cards/PriceCard.tsx
+++ b/components/cards/PriceCard.tsx
@@ -1,0 +1,40 @@
+import { Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { formatCurrency } from "@/lib/utils";
+import { WHATSAPP_URL } from "@/lib/constants";
+
+interface PriceCardProps {
+  title: string;
+  subtitle: string;
+  successFee: number;
+  features: string[];
+}
+
+export function PriceCard({ title, subtitle, successFee, features }: PriceCardProps) {
+  return (
+    <article className="flex h-full flex-col rounded-2xl border border-slate-200 bg-white p-8 shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+      <header>
+        <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">{title}</p>
+        <h3 className="mt-1 text-2xl font-bold text-slate-900">{subtitle}</h3>
+        <p className="mt-4 text-sm text-slate-600">
+          Success fee {formatCurrency(successFee)}
+        </p>
+      </header>
+      <ul className="mt-6 space-y-3 text-sm text-slate-700">
+        {features.map((feature) => (
+          <li key={feature} className="flex items-start gap-3">
+            <Check className="mt-0.5 h-4 w-4 text-emerald-500" aria-hidden="true" />
+            <span>{feature}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-8">
+        <Button asChild className="w-full">
+          <a href={WHATSAPP_URL} target="_blank" rel="noreferrer noopener">
+            Start My Recovery
+          </a>
+        </Button>
+      </div>
+    </article>
+  );
+}

--- a/components/cards/ServiceCard.tsx
+++ b/components/cards/ServiceCard.tsx
@@ -1,0 +1,22 @@
+import { BadgeCheck } from "lucide-react";
+
+interface ServiceCardProps {
+  title: string;
+  description: string;
+  includedIn: string;
+}
+
+export function ServiceCard({ title, description, includedIn }: ServiceCardProps) {
+  return (
+    <article className="group flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg focus-within:shadow-lg">
+      <div>
+        <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
+        <p className="mt-2 text-sm text-slate-600">{description}</p>
+      </div>
+      <div className="mt-6 inline-flex items-center gap-2 rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700">
+        <BadgeCheck className="h-4 w-4" aria-hidden="true" />
+        <span>Included in: {includedIn}</span>
+      </div>
+    </article>
+  );
+}

--- a/components/cards/StepCard.tsx
+++ b/components/cards/StepCard.tsx
@@ -1,0 +1,17 @@
+interface StepCardProps {
+  step: number;
+  title: string;
+  description: string;
+}
+
+export function StepCard({ step, title, description }: StepCardProps) {
+  return (
+    <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-blue-600 text-lg font-bold text-white">
+        {step}
+      </div>
+      <h3 className="mt-4 text-lg font-semibold text-slate-900">{title}</h3>
+      <p className="mt-2 text-sm text-slate-600">{description}</p>
+    </article>
+  );
+}

--- a/components/cards/TestimonialCard.tsx
+++ b/components/cards/TestimonialCard.tsx
@@ -1,0 +1,17 @@
+interface TestimonialCardProps {
+  quote: string;
+  name: string;
+  role: string;
+}
+
+export function TestimonialCard({ quote, name, role }: TestimonialCardProps) {
+  return (
+    <figure className="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <blockquote className="text-sm text-slate-700">“{quote}”</blockquote>
+      <figcaption className="mt-4 text-sm font-semibold text-slate-900">
+        {name}
+        <span className="ml-1 font-normal text-slate-500">— {role}</span>
+      </figcaption>
+    </figure>
+  );
+}

--- a/components/forms/ContactForm.tsx
+++ b/components/forms/ContactForm.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/forms/FormField";
+import { CASE_URL, OPS_URL } from "@/lib/constants";
+import { caseSchema, platformOptions, urgencyOptions, type CaseInput } from "@/lib/schemas";
+
+export function ContactForm() {
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm<CaseInput>({
+    resolver: zodResolver(caseSchema),
+    defaultValues: {
+      name: "",
+      email: "",
+      phone: "",
+      platform: "Instagram",
+      urgency: "Normal",
+      message: "",
+      honey: ""
+    }
+  });
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    setStatus(null);
+    setError(null);
+    try {
+      const res = await fetch(CASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: values.name,
+          email: values.email,
+          phone: values.phone || undefined,
+          platform: values.platform,
+          urgency: values.urgency,
+          message: values.message
+        })
+      });
+      if (!res.ok) {
+        throw new Error("Case submission failed");
+      }
+      const data = await res.json();
+      setStatus(`Case created: ${data.id}`);
+      await fetch(OPS_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ caseId: data.id, email: values.email, platform: values.platform })
+      });
+      form.reset();
+    } catch (submissionError) {
+      setError("We couldn’t submit your case. Please try again.");
+    }
+  });
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4" noValidate>
+      <FormField label="Full name" htmlFor="contact-name" error={form.formState.errors.name?.message}>
+        <input
+          type="text"
+          {...form.register("name")}
+          className="w-full rounded-2xl border border-slate-200 p-3 text-sm"
+          autoComplete="name"
+        />
+      </FormField>
+      <FormField label="Email" htmlFor="contact-email" error={form.formState.errors.email?.message}>
+        <input
+          type="email"
+          {...form.register("email")}
+          className="w-full rounded-2xl border border-slate-200 p-3 text-sm"
+          autoComplete="email"
+        />
+      </FormField>
+      <FormField
+        label="Phone (optional)"
+        htmlFor="contact-phone"
+        helpText="Only used for urgent coordination."
+        error={form.formState.errors.phone?.message}
+      >
+        <input
+          type="tel"
+          {...form.register("phone")}
+          className="w-full rounded-2xl border border-slate-200 p-3 text-sm"
+          autoComplete="tel"
+        />
+      </FormField>
+      <FormField
+        label="Platform"
+        htmlFor="contact-platform"
+        error={form.formState.errors.platform?.message}
+      >
+        <select
+          {...form.register("platform")}
+          className="w-full rounded-2xl border border-slate-200 bg-white p-3 text-sm"
+        >
+          {platformOptions.map((platform) => (
+            <option key={platform} value={platform}>
+              {platform}
+            </option>
+          ))}
+        </select>
+      </FormField>
+      <FormField
+        label="Urgency"
+        htmlFor="contact-urgency"
+        error={form.formState.errors.urgency?.message}
+      >
+        <select
+          {...form.register("urgency")}
+          className="w-full rounded-2xl border border-slate-200 bg-white p-3 text-sm"
+        >
+          {urgencyOptions.map((urgency) => (
+            <option key={urgency} value={urgency}>
+              {urgency}
+            </option>
+          ))}
+        </select>
+      </FormField>
+      <FormField
+        label="What happened?"
+        htmlFor="contact-message"
+        helpText="Please do not include passwords, passcodes, or 2FA codes."
+        error={form.formState.errors.message?.message}
+      >
+        <textarea
+          {...form.register("message")}
+          className="min-h-[120px] w-full rounded-2xl border border-slate-200 p-3 text-sm"
+          placeholder="Share what changed, any emails from the platform, and what you’ve tried."
+        />
+      </FormField>
+      <div className="hidden">
+        <label htmlFor="contact-honey">Do not fill</label>
+        <input id="contact-honey" type="text" {...form.register("honey")} tabIndex={-1} autoComplete="off" />
+      </div>
+      <Button type="submit" className="w-full">
+        Start My Recovery
+      </Button>
+      {status ? (
+        <p className="rounded-2xl bg-emerald-100 px-3 py-2 text-sm font-semibold text-emerald-700">{status}</p>
+      ) : null}
+      {error ? (
+        <p className="rounded-2xl bg-red-100 px-3 py-2 text-sm font-semibold text-red-700">{error}</p>
+      ) : null}
+    </form>
+  );
+}

--- a/components/forms/FormField.tsx
+++ b/components/forms/FormField.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface FormFieldProps extends React.HTMLAttributes<HTMLDivElement> {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+  helpText?: string;
+  error?: string;
+}
+
+export function FormField({
+  label,
+  htmlFor,
+  children,
+  helpText,
+  error,
+  className,
+  ...props
+}: FormFieldProps) {
+  const descriptionId = helpText ? `${htmlFor}-description` : undefined;
+  const errorId = error ? `${htmlFor}-error` : undefined;
+  return (
+    <div className={cn("space-y-2", className)} {...props}>
+      <label
+        className="text-sm font-medium text-slate-800"
+        htmlFor={htmlFor}
+      >
+        {label}
+      </label>
+      {React.isValidElement(children)
+        ? React.cloneElement(children, {
+            id: htmlFor,
+            "aria-describedby": [descriptionId, errorId]
+              .filter(Boolean)
+              .join(" ")
+              .trim() || undefined,
+            "aria-invalid": Boolean(error) || undefined
+          })
+        : children}
+      {helpText && !error ? (
+        <p id={descriptionId} className="text-xs text-slate-500">
+          {helpText}
+        </p>
+      ) : null}
+      {error ? (
+        <p id={errorId} className="text-xs font-medium text-red-600">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/components/home/HomeContent.tsx
+++ b/components/home/HomeContent.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { motion } from "framer-motion";
+import { ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ServiceCard } from "@/components/cards/ServiceCard";
+import { TestimonialCard } from "@/components/cards/TestimonialCard";
+import { StepCard } from "@/components/cards/StepCard";
+import { FormField } from "@/components/forms/FormField";
+import { WhatsAppCTA } from "@/components/WhatsAppCTA";
+import { CASE_URL, OPS_URL, TRUST_BADGE, WHATSAPP_URL } from "@/lib/constants";
+import { caseSchema, platformOptions, urgencyOptions, type CaseInput } from "@/lib/schemas";
+import { usePageview } from "@/lib/analytics";
+
+const services = [
+  {
+    title: "Instagram Account Recovery",
+    description: "Hacked, email changed, or disabled.",
+    includedIn: "Basic/Standard/Priority"
+  },
+  {
+    title: "Facebook Account/Page Recovery",
+    description: "Owner verification, admin hijack remediation.",
+    includedIn: "Standard/Priority"
+  },
+  {
+    title: "TikTok Account Recovery",
+    description: "Locked, banned, or restricted.",
+    includedIn: "Standard/Priority"
+  },
+  {
+    title: "X / Twitter Access Recovery",
+    description: "Compromised login, suspended handles.",
+    includedIn: "Standard/Priority"
+  },
+  {
+    title: "YouTube/Google Brand Recovery",
+    description: "Channel hijacks, brand account access.",
+    includedIn: "Priority"
+  },
+  {
+    title: "Impersonation Takedown",
+    description: "Remove fake profiles with evidence packs.",
+    includedIn: "Standard/Priority"
+  },
+  {
+    title: "Shadowban Review",
+    description: "Policy review to restore reach.",
+    includedIn: "Basic/Standard"
+  },
+  {
+    title: "2FA Setup & Hardening",
+    description: "App-based 2FA, backup codes, hygiene.",
+    includedIn: "Standard/Priority"
+  }
+];
+
+const testimonials = [
+  {
+    quote: "They recovered our agency client’s Instagram in two days without asking for any risky information.",
+    name: "Alicia",
+    role: "Agency Director"
+  },
+  {
+    quote: "Clear playbook, constant updates, and we’re back online selling on Facebook Shop.",
+    name: "Hafiz",
+    role: "SME Owner"
+  },
+  {
+    quote: "Priority tier was worth it. They handled the impersonation report end-to-end.",
+    name: "Maya",
+    role: "Content Creator"
+  }
+];
+
+const steps = [
+  {
+    step: 1,
+    title: "Share the incident",
+    description: "Tell us what happened, the platform involved, and any warnings received."
+  },
+  {
+    step: 2,
+    title: "Analyst triage",
+    description: "We verify ownership, gather safe evidence, and draft compliant appeals."
+  },
+  {
+    step: 3,
+    title: "Recovery & hardening",
+    description: "We work with you on secure recovery, 2FA, and impersonation takedowns if needed."
+  }
+];
+
+export function HomeContent() {
+  usePageview("/", "Home");
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm<CaseInput>({
+    resolver: zodResolver(caseSchema),
+    defaultValues: {
+      name: "",
+      email: "",
+      phone: "",
+      platform: "Instagram",
+      urgency: "Normal",
+      message: "",
+      honey: ""
+    }
+  });
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    setStatus(null);
+    setError(null);
+    try {
+      const res = await fetch(CASE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: values.name,
+          email: values.email,
+          phone: values.phone || undefined,
+          platform: values.platform,
+          urgency: values.urgency,
+          message: values.message
+        })
+      });
+      if (!res.ok) {
+        throw new Error("Case submission failed");
+      }
+      const data = await res.json();
+      setStatus(`Case created: ${data.id}`);
+      await fetch(OPS_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ caseId: data.id, email: values.email, platform: values.platform })
+      });
+      form.reset();
+    } catch (submissionError) {
+      setError("We couldn’t submit your case. Please try again.");
+    }
+  });
+
+  return (
+    <div className="space-y-20">
+      <section
+        className="rounded-2xl bg-hero-gradient p-10 shadow-soft"
+        aria-labelledby="hero-heading"
+      >
+        <div className="grid gap-12 md:grid-cols-2 md:items-center">
+          <div className="space-y-6">
+            <motion.div initial={{ opacity: 0, y: 16 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}>
+              <h1 id="hero-heading" className="text-4xl font-bold text-slate-900">
+                Recover Your Social Media Accounts — Fast, Secure, Ethical
+              </h1>
+              <p className="text-lg text-slate-700">
+                Locked out, hacked, or disabled? We restore access to Instagram, Facebook, TikTok, X/Twitter, YouTube and more.
+              </p>
+              <p className="text-sm font-medium text-slate-600">{TRUST_BADGE}</p>
+            </motion.div>
+            <div className="flex flex-wrap items-center gap-4">
+              <Button asChild size="lg">
+                <a href="#recovery-form">Start My Recovery</a>
+              </Button>
+              <Button asChild variant="outline" size="lg">
+                <Link href={WHATSAPP_URL} target="_blank" rel="noreferrer noopener">
+                  Message us on WhatsApp
+                </Link>
+              </Button>
+            </div>
+            <div className="flex items-center gap-3 rounded-2xl bg-white/80 p-4 text-sm text-slate-700">
+              <ShieldCheck className="h-5 w-5 text-blue-600" aria-hidden="true" />
+              <p>
+                We operate lawfully, independently, and never ask for your passwords or recovery codes.
+              </p>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-blue-100 bg-white p-6 shadow-lg">
+            <h2 className="text-lg font-semibold text-slate-900">What we handle</h2>
+            <ul className="mt-4 space-y-2 text-sm text-slate-700">
+              <li>Account hijacks and lockouts</li>
+              <li>Disabled creator and business pages</li>
+              <li>Impersonation and shadowban triage</li>
+              <li>Post-recovery hardening and 2FA setup</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section id="services" aria-labelledby="services-heading" className="space-y-10">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h2 id="services-heading" className="text-3xl font-bold text-slate-900">
+              Full-spectrum social account response
+            </h2>
+            <p className="mt-2 text-sm text-slate-600">
+              Instagram, Facebook, TikTok, X/Twitter, YouTube — we navigate platform policies and documentation so you don’t have to.
+            </p>
+          </div>
+        </div>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {services.map((service) => (
+            <ServiceCard key={service.title} {...service} />
+          ))}
+        </div>
+      </section>
+
+      <section id="testimonials" aria-labelledby="testimonials-heading" className="space-y-8">
+        <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h2 id="testimonials-heading" className="text-3xl font-bold text-slate-900">
+              Proof from Malaysian brands and creators
+            </h2>
+            <p className="text-sm text-slate-600">
+              Hear how we restored vital channels without compromising security.
+            </p>
+          </div>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {testimonials.map((testimonial) => (
+            <TestimonialCard key={testimonial.name} {...testimonial} />
+          ))}
+        </div>
+      </section>
+
+      <WhatsAppCTA />
+
+      <section aria-labelledby="steps-heading" className="space-y-6">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <h2 id="steps-heading" className="text-3xl font-bold text-slate-900">
+            How Social Safe works
+          </h2>
+          <p className="text-sm text-slate-600">
+            Transparent playbooks, documented evidence packs, and constant updates.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {steps.map((step) => (
+            <StepCard key={step.step} {...step} />
+          ))}
+        </div>
+      </section>
+
+      <section id="recovery-form" aria-labelledby="recovery-heading" className="space-y-6">
+        <div className="grid gap-10 lg:grid-cols-2">
+          <div className="space-y-4">
+            <h2 id="recovery-heading" className="text-3xl font-bold text-slate-900">
+              Start Your Recovery
+            </h2>
+            <p className="text-sm text-slate-600">
+              Submit the secure intake form. We’ll reply within business hours with next steps. We’ll never ask for your passwords or 2FA codes.
+            </p>
+            <p className="rounded-2xl bg-white p-4 text-sm text-slate-700 shadow-sm">
+              We charge a RM 100 advance to open a case. This is non-refundable and covers analyst time and evidence preparation. You only pay the remaining success fee if we recover access.
+            </p>
+          </div>
+          <form
+            onSubmit={onSubmit}
+            className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+            noValidate
+          >
+            <FormField label="Full name" htmlFor="name" error={form.formState.errors.name?.message}>
+              <input
+                type="text"
+                {...form.register("name")}
+                className="w-full rounded-2xl border border-slate-200 p-3 text-sm"
+                autoComplete="name"
+              />
+            </FormField>
+            <FormField label="Email" htmlFor="email" error={form.formState.errors.email?.message}>
+              <input
+                type="email"
+                {...form.register("email")}
+                className="w-full rounded-2xl border border-slate-200 p-3 text-sm"
+                autoComplete="email"
+              />
+            </FormField>
+            <FormField
+              label="Phone (optional)"
+              htmlFor="phone"
+              helpText="Only used for urgent coordination."
+              error={form.formState.errors.phone?.message}
+            >
+              <input
+                type="tel"
+                {...form.register("phone")}
+                className="w-full rounded-2xl border border-slate-200 p-3 text-sm"
+                autoComplete="tel"
+              />
+            </FormField>
+            <FormField
+              label="Platform"
+              htmlFor="platform"
+              error={form.formState.errors.platform?.message}
+            >
+              <select
+                {...form.register("platform")}
+                className="w-full rounded-2xl border border-slate-200 bg-white p-3 text-sm"
+              >
+                {platformOptions.map((platform) => (
+                  <option key={platform} value={platform}>
+                    {platform}
+                  </option>
+                ))}
+              </select>
+            </FormField>
+            <FormField
+              label="Urgency"
+              htmlFor="urgency"
+              error={form.formState.errors.urgency?.message}
+            >
+              <select
+                {...form.register("urgency")}
+                className="w-full rounded-2xl border border-slate-200 bg-white p-3 text-sm"
+              >
+                {urgencyOptions.map((urgency) => (
+                  <option key={urgency} value={urgency}>
+                    {urgency}
+                  </option>
+                ))}
+              </select>
+            </FormField>
+            <FormField
+              label="What happened?"
+              htmlFor="message"
+              helpText="Please do not include passwords, passcodes, or 2FA codes."
+              error={form.formState.errors.message?.message}
+            >
+              <textarea
+                {...form.register("message")}
+                className="min-h-[120px] w-full rounded-2xl border border-slate-200 p-3 text-sm"
+                placeholder="Share what changed, any emails from the platform, and what you’ve tried."
+              />
+            </FormField>
+            <div className="hidden">
+              <label htmlFor="honey">Do not fill</label>
+              <input id="honey" type="text" {...form.register("honey")} tabIndex={-1} autoComplete="off" />
+            </div>
+            <Button type="submit" className="w-full">
+              Start My Recovery
+            </Button>
+            {status ? (
+              <p className="rounded-2xl bg-emerald-100 px-3 py-2 text-sm font-semibold text-emerald-700">
+                {status}
+              </p>
+            ) : null}
+            {error ? (
+              <p className="rounded-2xl bg-red-100 px-3 py-2 text-sm font-semibold text-red-700">
+                {error}
+              </p>
+            ) : null}
+          </form>
+        </div>
+      </section>
+
+      <section aria-labelledby="team-heading" className="space-y-6">
+        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <h2 id="team-heading" className="text-3xl font-bold text-slate-900">
+            Meet the team
+          </h2>
+          <p className="text-sm text-slate-600">
+            Social Safe is led by security professionals recognised by global platforms.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h3 className="text-xl font-semibold text-slate-900">Shuvonsec — Founder & CEO. Cybersecurity researcher, ethical hacker & bug bounty hunter with global recognition.</h3>
+          </article>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/layout/AssistWidget.tsx
+++ b/components/layout/AssistWidget.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import { MessageSquare } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ASSIST_URL } from "@/lib/constants";
+
+interface Message {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export function AssistWidget() {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [escalate, setEscalate] = useState(false);
+  const [escalated, setEscalated] = useState(false);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const nextMessages = [...messages, { role: "user" as const, content: input.trim() }];
+    setMessages(nextMessages);
+    setInput("");
+    setLoading(true);
+    try {
+      const res = await fetch(ASSIST_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: nextMessages })
+      });
+      if (!res.ok) {
+        throw new Error("Failed");
+      }
+      const data = await res.json();
+      setMessages((prev) => [...prev, { role: "assistant", content: data.reply }] as Message[]);
+    } catch (error) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: "assistant",
+          content:
+            "Sorry, I couldn’t reach the assistant. You can escalate to a human specialist below."
+        }
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed bottom-6 right-6 z-40 flex flex-col items-end gap-3">
+      {open ? (
+        <div className="w-80 rounded-2xl border border-slate-200 bg-white p-4 shadow-lg">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold text-slate-900">Need quick guidance?</p>
+            <button
+              className="focus-ring text-xs text-slate-500"
+              onClick={() => setOpen(false)}
+              type="button"
+            >
+              Close
+            </button>
+          </div>
+          <div className="mt-3 max-h-48 space-y-3 overflow-y-auto" aria-live="polite">
+            {messages.length === 0 ? (
+              <p className="text-xs text-slate-500">
+                Ask our internal assistant for tips. We never ask for passwords.
+              </p>
+            ) : (
+              messages.map((message, index) => (
+                <p
+                  key={index}
+                  className={`text-xs ${
+                    message.role === "assistant" ? "text-blue-700" : "text-slate-700"
+                  }`}
+                >
+                  <span className="font-semibold capitalize">{message.role}:</span> {message.content}
+                </p>
+              ))
+            )}
+          </div>
+          <form
+            className="mt-3 space-y-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              sendMessage();
+            }}
+          >
+            <label className="sr-only" htmlFor="assist-input">
+              Message
+            </label>
+            <textarea
+              id="assist-input"
+              className="w-full rounded-2xl border border-slate-200 p-2 text-sm"
+              rows={2}
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              placeholder="Ask a question..."
+            />
+            <Button type="submit" size="sm" disabled={loading} className="w-full">
+              {loading ? "Sending..." : "Send"}
+            </Button>
+          </form>
+          <div className="mt-4 border-t border-slate-200 pt-3">
+            <button
+              type="button"
+              className="text-xs font-semibold text-blue-600 underline-offset-4 hover:underline"
+              onClick={() => setEscalate((prev) => !prev)}
+            >
+              {escalate ? "Hide human escalation" : "Escalate to human"}
+            </button>
+            {escalate ? (
+              <form
+                className="mt-3 space-y-2"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  setEscalated(true);
+                }}
+              >
+                <label className="sr-only" htmlFor="assist-email">
+                  Email
+                </label>
+                <input
+                  id="assist-email"
+                  type="email"
+                  required
+                  className="w-full rounded-2xl border border-slate-200 p-2 text-sm"
+                  placeholder="Email for follow-up"
+                />
+                <Button type="submit" size="sm" variant="outline" className="w-full">
+                  Request human support
+                </Button>
+                {escalated ? (
+                  <p className="text-xs text-emerald-600">
+                    Thank you. A specialist will reach out shortly.
+                  </p>
+                ) : null}
+              </form>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+      <Button
+        type="button"
+        variant="default"
+        size="lg"
+        className="shadow-lg"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <MessageSquare className="mr-2 h-5 w-5" aria-hidden="true" />
+        {open ? "Close" : "Need help?"}
+      </Button>
+    </div>
+  );
+}

--- a/components/layout/ConsentBanner.tsx
+++ b/components/layout/ConsentBanner.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+const STORAGE_KEY = "socialsafe-consent";
+
+type ConsentState = "unknown" | "accepted" | "declined";
+
+export function ConsentBanner() {
+  const [state, setState] = useState<ConsentState>("unknown");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY) as ConsentState | null;
+    if (stored) {
+      setState(stored);
+    }
+  }, []);
+
+  if (state !== "unknown") {
+    return null;
+  }
+
+  const accept = () => {
+    window.localStorage.setItem(STORAGE_KEY, "accepted");
+    setState("accepted");
+  };
+
+  const decline = () => {
+    window.localStorage.setItem(STORAGE_KEY, "declined");
+    setState("declined");
+  };
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 mx-auto max-w-3xl rounded-t-2xl border border-slate-200 bg-white p-4 shadow-lg">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <p className="text-sm text-slate-700">
+          We use a privacy-friendly, cookie-less analytics tool to understand page views. No personal data is stored.
+        </p>
+        <div className="flex items-center gap-2">
+          <Button variant="subtle" size="sm" onClick={decline}>
+            Decline
+          </Button>
+          <Button size="sm" onClick={accept}>
+            Accept
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { SITE_NAME } from "@/lib/constants";
+
+const year = new Date().getFullYear();
+
+export function Footer() {
+  return (
+    <footer className="border-t border-slate-200 bg-white py-10" role="contentinfo">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="text-lg font-semibold text-slate-900">{SITE_NAME}</p>
+          <p className="mt-2 text-sm text-slate-600">
+            We operate independently and follow platform policies and applicable laws.
+          </p>
+        </div>
+        <nav aria-label="Footer" className="flex flex-col gap-4 text-sm text-slate-600 md:flex-row md:items-center md:gap-6">
+          <Link href="/">Home</Link>
+          <Link href="/pricing">Pricing</Link>
+          <Link href="/contact">Contact</Link>
+          <Link href="/privacy">Privacy</Link>
+          <Link href="/terms">Terms</Link>
+        </nav>
+        <p className="text-xs text-slate-500">© {year} {SITE_NAME}. All rights reserved.</p>
+      </div>
+    </footer>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Menu, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { SITE_NAME, WHATSAPP_URL } from "@/lib/constants";
+
+const navItems = [
+  { href: "#services", label: "Services" },
+  { href: "/pricing", label: "Pricing" },
+  { href: "#testimonials", label: "Testimonials" },
+  { href: WHATSAPP_URL, label: "WhatsApp", external: true },
+  { href: "/contact", label: "Contact" }
+];
+
+export function Header() {
+  const [open, setOpen] = useState(false);
+
+  const close = () => setOpen(false);
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/70">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
+        <Link
+          href="/"
+          className="flex items-center gap-2 text-lg font-semibold text-slate-900"
+          aria-label={SITE_NAME}
+        >
+          <span className="h-3 w-3 rounded-full bg-blue-600" aria-hidden="true" />
+          {SITE_NAME}
+        </Link>
+        <nav className="hidden items-center gap-8 text-sm font-medium text-slate-700 md:flex">
+          {navItems.map((item) => (
+            <Link
+              key={item.label}
+              href={item.href}
+              target={item.external ? "_blank" : undefined}
+              rel={item.external ? "noreferrer noopener" : undefined}
+              className="transition hover:text-blue-600"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="hidden md:block">
+          <Button asChild>
+            <Link href={WHATSAPP_URL} target="_blank" rel="noreferrer noopener">
+              Start My Recovery
+            </Link>
+          </Button>
+        </div>
+        <button
+          type="button"
+          className="focus-ring inline-flex items-center justify-center rounded-2xl p-2 text-slate-700 md:hidden"
+          onClick={() => setOpen((prev) => !prev)}
+          aria-expanded={open}
+          aria-controls="mobile-nav"
+        >
+          <span className="sr-only">Toggle navigation</span>
+          {open ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
+        </button>
+      </div>
+      {open ? (
+        <nav
+          id="mobile-nav"
+          className="border-t border-slate-200 bg-white px-4 py-4 md:hidden"
+        >
+          <ul className="space-y-4 text-sm font-medium text-slate-700">
+            {navItems.map((item) => (
+              <li key={item.label}>
+                <Link
+                  href={item.href}
+                  target={item.external ? "_blank" : undefined}
+                  rel={item.external ? "noreferrer noopener" : undefined}
+                  onClick={close}
+                  className="block rounded-xl px-3 py-2 hover:bg-blue-50 hover:text-blue-600"
+                >
+                  {item.label}
+                </Link>
+              </li>
+            ))}
+            <li>
+              <Button asChild className="w-full">
+                <Link
+                  href={WHATSAPP_URL}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  onClick={close}
+                >
+                  Start My Recovery
+                </Link>
+              </Button>
+            </li>
+          </ul>
+        </nav>
+      ) : null}
+    </header>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-2xl text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-60",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-blue-600 text-white shadow-soft hover:bg-blue-500 focus-visible:ring-blue-500",
+        outline:
+          "border border-blue-600 text-blue-600 hover:bg-blue-50 focus-visible:ring-blue-500",
+        ghost: "text-blue-600 hover:bg-blue-50",
+        subtle:
+          "bg-slate-100 text-slate-900 hover:bg-slate-200 focus-visible:ring-slate-400"
+      },
+      size: {
+        default: "px-5 py-3",
+        sm: "px-3 py-2 text-xs",
+        lg: "px-6 py-3 text-base",
+        icon: "h-10 w-10 p-0"
+      }
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default"
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+
+type PageviewAdapter = {
+  track: (data: { path: string; title?: string }) => void;
+};
+
+const adapters: PageviewAdapter[] = [];
+
+export function registerAnalyticsAdapter(adapter: PageviewAdapter) {
+  adapters.push(adapter);
+}
+
+export function usePageview(path: string, title?: string) {
+  useEffect(() => {
+    for (const adapter of adapters) {
+      try {
+        adapter.track({ path, title });
+      } catch (error) {
+        console.warn("analytics adapter failed", (error as Error).message);
+      }
+    }
+  }, [path, title]);
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,16 @@
+export const SITE_NAME = "Social Safe";
+export const SITE_URL = "https://www.socialsafe.my";
+export const WHATSAPP_URL =
+  process.env.NEXT_PUBLIC_WHATSAPP_URL ?? "https://wa.me/60123456789";
+export const ASSIST_URL =
+  process.env.NEXT_PUBLIC_SOCIALSAFE_ASSIST_URL ?? "/api/assist";
+export const CASE_URL =
+  process.env.NEXT_PUBLIC_SOCIALSAFE_CASE_URL ?? "/api/cases";
+export const OPS_URL =
+  process.env.NEXT_PUBLIC_SOCIALSAFE_OPS_URL ?? "/api/notify-ops";
+export const BUSINESS_HOURS_BADGE = "9am–10pm MYT";
+export const TRUST_BADGE =
+  "Trusted by creators, SMEs, and agencies across Malaysia.";
+export const RATE_LIMIT_TOKENS_PER_MINUTE = Number(
+  process.env.RATE_LIMIT_TOKENS_PER_MINUTE ?? 30
+);

--- a/lib/notify-ops.ts
+++ b/lib/notify-ops.ts
@@ -1,0 +1,26 @@
+import { OPS_URL } from "./constants";
+import { notifyOpsSchema } from "./schemas";
+
+export async function notifyOps(input: unknown) {
+  const payload = notifyOpsSchema.parse(input);
+  if (process.env.NODE_ENV === "test") {
+    return { ok: true };
+  }
+  try {
+    const res = await fetch(OPS_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to notify ops: ${res.status}`);
+    }
+    return res.json();
+  } catch (error) {
+    console.error("[notifyOps]", {
+      message: (error as Error).message,
+      caseId: payload.caseId ?? "n/a"
+    });
+    return { ok: false };
+  }
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,26 @@
+const tokensPerMinute = Number(process.env.RATE_LIMIT_TOKENS_PER_MINUTE ?? 30);
+
+const buckets = new Map<string, { tokens: number; updatedAt: number }>();
+
+export function checkRateLimit(key: string) {
+  const now = Date.now();
+  const bucket = buckets.get(key);
+  const refillRate = tokensPerMinute / 60000; // tokens per ms
+  if (!bucket) {
+    buckets.set(key, { tokens: tokensPerMinute - 1, updatedAt: now });
+    return true;
+  }
+  const elapsed = now - bucket.updatedAt;
+  const tokens = Math.min(
+    tokensPerMinute,
+    bucket.tokens + elapsed * refillRate
+  );
+  if (tokens < 1) {
+    bucket.tokens = tokens;
+    bucket.updatedAt = now;
+    return false;
+  }
+  bucket.tokens = tokens - 1;
+  bucket.updatedAt = now;
+  return true;
+}

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+export const platformOptions = [
+  "Instagram",
+  "Facebook",
+  "TikTok",
+  "X / Twitter",
+  "YouTube"
+] as const;
+
+export const urgencyOptions = ["Normal", "Priority"] as const;
+
+export const caseSchema = z
+  .object({
+    name: z.string().min(1, "Name is required"),
+    email: z.string().email("Enter a valid email"),
+    phone: z
+      .string()
+      .optional()
+      .transform((val) => (val ? val.trim() : val)),
+    platform: z.enum(platformOptions, {
+      errorMap: () => ({ message: "Choose a platform" })
+    }),
+    urgency: z.enum(urgencyOptions).default("Normal"),
+    message: z
+      .string()
+      .min(10, "Tell us what happened")
+      .refine(
+        (value) => !/password|passcode|otp/i.test(value),
+        "For your security, please do not share passwords or codes."
+      ),
+    transcript: z
+      .array(
+        z.object({
+          role: z.enum(["user", "assistant"]),
+          content: z.string().min(1)
+        })
+      )
+      .optional(),
+    honey: z.string().optional().default("")
+  })
+  .superRefine((data, ctx) => {
+    if (data.honey && data.honey.trim().length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["honey"],
+        message: "Invalid submission"
+      });
+    }
+  });
+
+export type CaseInput = z.infer<typeof caseSchema>;
+
+export const notifyOpsSchema = z.object({
+  caseId: z.string().optional(),
+  email: z.string().email(),
+  platform: z.string().optional(),
+  transcript: z
+    .array(
+      z.object({
+        role: z.enum(["user", "assistant"]),
+        content: z.string()
+      })
+    )
+    .optional()
+});
+
+export const assistSchema = z.object({
+  messages: z
+    .array(
+      z.object({
+        role: z.enum(["user", "assistant"]),
+        content: z.string().min(1)
+      })
+    )
+    .min(1),
+  meta: z.record(z.unknown()).optional()
+});

--- a/lib/store/cases.ts
+++ b/lib/store/cases.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from "crypto";
+import type { CaseInput } from "../schemas";
+
+type CaseRecord = {
+  id: string;
+  createdAt: Date;
+  name: string;
+  email: string;
+  phone?: string;
+  platform: CaseInput["platform"];
+  urgency: CaseInput["urgency"];
+  message: string;
+  status: "new" | "in_progress" | "resolved";
+  locale: string;
+};
+
+const cases = new Map<string, CaseRecord>();
+
+export async function createCase(input: CaseInput) {
+  const id = randomUUID();
+  const record: CaseRecord = {
+    id,
+    createdAt: new Date(),
+    name: input.name,
+    email: input.email,
+    phone: input.phone,
+    platform: input.platform,
+    urgency: input.urgency,
+    message: input.message,
+    status: "new",
+    locale: "en-MY"
+  };
+  cases.set(id, record);
+  return record;
+}
+
+export function getCase(id: string) {
+  return cases.get(id);
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,14 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export function formatCurrency(amount: number, locale = "ms-MY") {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: "MYR",
+    minimumFractionDigits: 0
+  }).format(amount);
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,13 @@
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "social-safe",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest",
+    "postinstall": "prisma generate"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3.3.4",
+    "@prisma/client": "^5.15.0",
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-icons": "^1.3.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "framer-motion": "^11.0.17",
+    "lucide-react": "^0.364.0",
+    "next": "14.2.3",
+    "next-themes": "^0.2.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "react-hook-form": "^7.51.4",
+    "tailwind-merge": "^2.2.0",
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.4",
+    "@testing-library/react": "^14.3.1",
+    "@types/node": "^20.12.7",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.3",
+    "jsdom": "^24.0.0",
+    "postcss": "^8.4.38",
+    "prisma": "^5.15.0",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5",
+    "vitest": "^1.5.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,21 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Case {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  name      String
+  email     String
+  phone     String?
+  platform  String
+  urgency   String
+  message   String
+  status    String   @default("new")
+  locale    String   @default("en-MY")
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  await prisma.case.create({
+    data: {
+      name: "Demo Creator",
+      email: "demo@socialsafe.my",
+      platform: "Instagram",
+      urgency: "Normal",
+      message: "Seeded case for testing seeding pipeline.",
+      status: "resolved"
+    }
+  });
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,33 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["var(--font-sans)", "system-ui", "sans-serif"],
+        display: ["var(--font-display)", "system-ui", "sans-serif"]
+      },
+      borderRadius: {
+        "2xl": "1.5rem"
+      },
+      boxShadow: {
+        soft: "0 20px 45px -20px rgba(37, 99, 235, 0.25)"
+      },
+      backgroundImage: {
+        "hero-gradient":
+          "linear-gradient(135deg, rgba(59,130,246,0.15), rgba(14,165,233,0.1))",
+        "whatsapp-gradient":
+          "linear-gradient(135deg, rgba(16,185,129,0.2), rgba(59,130,246,0.15))"
+      }
+    }
+  },
+  plugins: [require("tailwindcss-animate")]
+};
+
+export default config;

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { caseSchema } from "@/lib/schemas";
+
+describe("caseSchema", () => {
+  const base = {
+    name: "Test User",
+    email: "test@example.com",
+    phone: "",
+    platform: "Instagram" as const,
+    urgency: "Normal" as const,
+    message: "Account hacked, email changed, need help",
+    transcript: [],
+    honey: ""
+  };
+
+  it("accepts valid payload", () => {
+    const parsed = caseSchema.parse(base);
+    expect(parsed.name).toBe("Test User");
+  });
+
+  it("rejects password content", () => {
+    expect(() =>
+      caseSchema.parse({
+        ...base,
+        message: "Here is my password 12345"
+      })
+    ).toThrowError(/do not share passwords/);
+  });
+
+  it("rejects honeypot", () => {
+    expect(() =>
+      caseSchema.parse({
+        ...base,
+        honey: "robot"
+      })
+    ).toThrow();
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { formatCurrency } from "@/lib/utils";
+
+describe("formatCurrency", () => {
+  it("formats whole numbers in MYR", () => {
+    expect(formatCurrency(199)).toBe("RM 199");
+  });
+
+  it("supports decimals", () => {
+    expect(formatCurrency(399.5)).toBe("RM 400");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts"],
+  "exclude": ["node_modules"]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "app/api/**/*.ts": {
+      "maxDuration": 10
+    }
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: [],
+    include: ["tests/**/*.test.ts"]
+  }
+});


### PR DESCRIPTION
## Summary
- implement a Next.js 14 app router layout with sticky navigation, consent banner, assist widget, and SEO metadata for Social Safe
- build the home, pricing, contact, privacy, and terms pages with mandated hero copy, services grid, WhatsApp CTAs, and recovery intake forms wired to new API routes
- add server endpoints, Prisma schema, rate limiting, and Vitest coverage for currency formatting and case schema guards

## Testing
- npm install *(fails: registry access returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dd0c293a14832599c523c84898a64a